### PR TITLE
Put requests in a session to benefit from connection reuse

### DIFF
--- a/flickrapi/auth.py
+++ b/flickrapi/auth.py
@@ -149,6 +149,8 @@ class FlickrAccessToken(object):
 class OAuthFlickrInterface(object):
     """Interface object for handling OAuth-authenticated calls to Flickr."""
 
+    session = requests.Session()
+
     REQUEST_TOKEN_URL = "https://www.flickr.com/services/oauth/request_token"
     AUTHORIZE_URL = "https://www.flickr.com/services/oauth/authorize"
     ACCESS_TOKEN_URL = "https://www.flickr.com/services/oauth/access_token"
@@ -245,10 +247,9 @@ class OAuthFlickrInterface(object):
         @return: the response content
         """
 
-        req = requests.post(url,
+        req = self.session.post(url,
                             params=params,
-                            auth=self.oauth,
-                            headers={'Connection': 'close'})
+                            auth=self.oauth)
 
         # check the response headers / status code.
         if req.status_code != 200:
@@ -277,8 +278,7 @@ class OAuthFlickrInterface(object):
         #   1. create a dummy request without 'photo'
         #   2. create real request and use auth headers from the dummy one
         dummy_req = requests.Request('POST', url, data=params,
-                                     auth=self.oauth,
-                                     headers={'Connection': 'close'})
+                                     auth=self.oauth)
 
         prepared = dummy_req.prepare()
         headers = prepared.headers
@@ -289,10 +289,9 @@ class OAuthFlickrInterface(object):
         params['photo'] = ('dummy name', fileobj)
         m = MultipartEncoder(fields=params)
         auth = {'Authorization': headers.get('Authorization'),
-                'Content-Type': m.content_type,
-                'Connection': 'close'}
+                'Content-Type': m.content_type}
         self.log.debug('POST %s', auth)
-        req = requests.post(url, data=m, headers=auth)
+        req = self.session.post(url, data=m, headers=auth)
 
         # check the response headers / status code.
         if req.status_code != 200:


### PR DESCRIPTION
By playing with logging, I discovered that a new https connection is opened each time a request is made to the API. Establishment can be time consuming, especially when you plan to upload many files (hundred GB, 20k files) in batch.

http://docs.python-requests.org/en/master/user/advanced/#session-objects
Changes : 
- Remove Connection: close, urllib3 will handle that
- Add class property session <= request.Session()
- And of course, request using this session when possible (still using request for fake headers creation, no method available in request.session to do that : https://github.com/kennethreitz/requests/blob/master/requests/sessions.py#L411)

Some numbers (small data set, and still wayyy lower than the upload 100Mbps of the connection) : 
* without reuse : 0m58s for 32,4 Mo ; 8m00s for 287,4 Mo
* with reuse : 0m42s for 32,4 Mo ; 0m51s for 32,4 Mo ; 5m53s for 287,4 Mo

Notes : 
- Class property might be an issue (security ?), but for my usage I don't care.
- Connection: closed was added for #50 it seems (https://github.com/sybrenstuvel/flickrapi/blob/bf32a652ffa97be69b48e368d5f8d4b9da5282f4/flickrapi/auth.py), but fo far there's no issues for me, python3.5)

